### PR TITLE
[NTUSER] Remove a wrong check in MENU_MouseMove

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -3683,20 +3683,7 @@ static BOOL FASTCALL MENU_MouseMove(MTRACKER *pmt, PMENU PtMenu, UINT Flags)
   UINT Index = NO_SELECTED_ITEM;
 
   if ( PtMenu )
-  {
-      if (IS_SYSTEM_MENU(PtMenu))
-      {
-          Index = 0;
-          //// ReactOS only HACK: CORE-2338
-          // Windows tracks mouse moves to the system menu but does not open it.
-          // Only keyboard tracking can do that.
-          //
-          TRACE("SystemMenu\n");
-          return TRUE; // Stay inside the Loop!
-      }
-      else
-          MENU_FindItemByCoords( PtMenu, pmt->Pt, &Index );
-  }
+      MENU_FindItemByCoords( PtMenu, pmt->Pt, &Index );
 
   if (Index == NO_SELECTED_ITEM)
   {


### PR DESCRIPTION
This check doesn't seem to be correct in modern ReactOS. Furthermore, it actually hadn't been working for a long time until it was uncovered by the recent system menu changes.

Fixes CORE-19170

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
