### PR TITLE
[NTOS:MM/x64] Temporarily release AddressCreationLock in MmCreateVirt…

### DIFF
--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -637,6 +637,9 @@ MmCreateVirtualMappingUnsafeEx(
     PMMPTE PointerPte;
     MMPTE TempPte;
     ULONG_PTR Pte;
+#ifdef _M_AMD64
+    BOOLEAN LockReleased = FALSE;
+#endif
 
     DPRINT("MmCreateVirtualMappingUnsafe(%p, %p, %lu, %x)\n",
            Process, Address, flProtect, Page);
@@ -664,6 +667,15 @@ MmCreateVirtualMappingUnsafeEx(
 #if _MI_PAGING_LEVELS == 2
         if (!MiSynchronizeSystemPde(MiAddressToPde(Address)))
             MiFillSystemPageDirectory(Address, PAGE_SIZE);
+#endif
+
+#ifdef _M_AMD64
+        /* This is a temporary hack, because we can incur a recursive page fault when accessing the PDE */
+        if (PsIdleProcess->AddressCreationLock.Owner == KeGetCurrentThread())
+        {
+            MmUnlockAddressSpace(MmGetKernelAddressSpace());
+            LockReleased = TRUE;
+        }
 #endif
     }
     else
@@ -715,6 +727,15 @@ MmCreateVirtualMappingUnsafeEx(
         MiIncrementPageTableReferences(Address);
         MiUnlockProcessWorkingSetUnsafe(Process, PsGetCurrentThread());
     }
+#ifdef _M_AMD64
+    else
+    {
+        if (LockReleased)
+        {
+            MmLockAddressSpace(MmGetKernelAddressSpace());
+        }
+    }
+#endif
 
     return(STATUS_SUCCESS);
 }


### PR DESCRIPTION
…ualMappingUnsafeEx

This is a hack, because the kernel mode path can incur a recursive page fault with the AddressCreationLock acquired, which would lead to a recursive acquisition, once we do proper locking in MmAccessFault. To properly fix this the PDE must be made valid, similar to the user mode path, but that is not that simple...

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
