### PR TITLE
[STLPORT] Make stl thread-safe

### DIFF
--- a/sdk/include/c++/stlport/stl/config/_reactos.h
+++ b/sdk/include/c++/stlport/stl/config/_reactos.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010
- * Jérôme Gardou
+ * JÃ©rÃ´me Gardou
  *
  *
  * This material is provided "as is", with absolutely no warranty expressed
@@ -301,6 +301,9 @@
 
 // Calling convention
 #define _STLP_CALL __cdecl
+
+// Always build multithreaded code
+#define _STLP_THREADS
 
 #if 0
 

--- a/sdk/include/c++/stlport/stl/config/_windows.h
+++ b/sdk/include/c++/stlport/stl/config/_windows.h
@@ -205,7 +205,7 @@ _STLP_IMPORT_DECLSPEC void _STLP_STDCALL OutputDebugStringA(const char* lpOutput
  * to avoid macro definition conflict. */
 #  if !defined (_WIN64)
 /* Under 32 bits platform we rely on a simple InterlockedExchange call. */
-#    if defined (__cplusplus) && defined(__BUILDING_STLPORT)
+#    if defined (__cplusplus)
 /* We do not define this function if we are not in a C++ translation unit just
  * because of the 'inline' keyword portability issue it would introduce. We will
  * have to fix it the day we need this function for a C translation unit.


### PR DESCRIPTION
Define _STLP_THREADS to make stl thread safe.
Also remove defined(__BUILDING_STLPORT) from the preprocessor conditions for which STLPInterlockedExchangePointer is defined, because that function is used in _threads.h, which can get included by apps using the stl through stl headers.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
