### PR TITLE
[DEVMGR] Fix some bugs spotted by Thomas Faber in PR #5775

### DIFF
--- a/dll/win32/devmgr/properties/advprop.cpp
+++ b/dll/win32/devmgr/properties/advprop.cpp
@@ -413,7 +413,7 @@ DriverDetailsDlgProc(IN HWND hwndDlg,
                                                  pnmv->iItem,
                                                  pnmv->iSubItem,
                                                  szDriverPath,
-                                                 MAX_PATH);
+                                                 _countof(szDriverPath));
 
                             UpdateDriverVersionInfoDetails(hwndDlg,
                                                            szDriverPath);
@@ -1944,16 +1944,11 @@ AdvProcDetailsDlgProc(IN HWND hwndDlg,
                         if (nSelectedId < 0 || nSelectedItems <= 0)
                             break;
 
-                        TCHAR szItemName[MAX_PATH];
                         HGLOBAL hGlobal;
                         LPWSTR pszBuffer;
+                        SIZE_T cchSize = MAX_PATH + 1;
 
-                        ListView_GetItemText(hwndListView,
-                                             nSelectedId, 0,
-                                             szItemName,
-                                             _countof(szItemName));
-
-                        hGlobal = GlobalAlloc(GHND, MAX_PATH);
+                        hGlobal = GlobalAlloc(GHND, cchSize * sizeof(WCHAR));
                         if (!hGlobal)
                             break;
                         pszBuffer = (LPWSTR)GlobalLock(hGlobal);
@@ -1963,7 +1958,12 @@ AdvProcDetailsDlgProc(IN HWND hwndDlg,
                             break;
                         }
 
-                        wsprintf(pszBuffer, L"%s", szItemName);
+                        ListView_GetItemText(hwndListView,
+                                             nSelectedId, 0,
+                                             pszBuffer,
+                                             cchSize);
+                        /* Ensure NULL-termination */
+                        pszBuffer[cchSize - 1] = UNICODE_NULL;
 
                         GlobalUnlock(hGlobal);
 


### PR DESCRIPTION
- Fix TCHAR/WCHAR mis-usage,
- Fix as a result, a buffer overflow (GlobalAlloc takes the size in bytes, but a number of characters was passed to it instead).
- Remove usage of unsafe string function. Now the item text is directly retrieved within the allocated buffer.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
