### PR TITLE
[CMAKE] Add GCC options to make a long double 64 bits

### DIFF
--- a/modules/rostests/winetests/msvcrt/CMakeLists.txt
+++ b/modules/rostests/winetests/msvcrt/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_definitions(msvcrt_winetest PRIVATE
     __msvcrt_ulong=ULONG)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(msvcrt_winetest PRIVATE -Wno-format -Wno-stringop-truncation)
+    target_compile_options(msvcrt_winetest PRIVATE -Wno-format -Wno-stringop-truncation -Wno-overflow)
 endif()
 
 set_module_type(msvcrt_winetest win32cui)

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -42,6 +42,9 @@ endif()
 # note: -fno-common is default since GCC 10
 add_compile_options(-pipe -fms-extensions -fno-strict-aliasing -fno-common)
 
+# A long double is 64 bits
+add_compile_options(-mlong-double-64)
+
 # Prevent GCC from searching any of the default directories.
 # The case for C++ is handled through the reactos_c++ INTERFACE library
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:CXX>>:-nostdinc>")


### PR DESCRIPTION
This adds -mlong-double-64 to make the size of a long double 64 bits in GCC builds to match MSVC builds.

## Purpose

_Do a quick recap of your work here._

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
